### PR TITLE
Sort the items by last seen

### DIFF
--- a/VineExplorer.user.js
+++ b/VineExplorer.user.js
@@ -810,6 +810,8 @@ function insertHtmlElementAfter(referenceNode, newNode) {
 async function createProductSite(siteType, productArray, cb) {
     if (!productArray) return;
 
+    productArray = sort_by_key(productArray, 'ts_lastSeen');
+    
     const _productArrayLength = productArray.length;
     const _fastCount = Math.min(_productArrayLength, SETTINGS.MaxItemsPerPage);
     if (SETTINGS.DebugLevel > 10) console.log(`Create Overview for ${_productArrayLength} Products`);
@@ -2974,4 +2976,14 @@ function init(hasTiles) {
         _pageinationContainer.appendChild(_btn);
         _pageinationContainer.appendChild(_AveNextArrow);
     }
+}
+
+//Sort Items by key
+function sort_by_key(array, key, order)
+{
+    return array.sort(function(a, b) {
+        var x = a[key]; var y = b[key];
+        const multiplier = order === "asc" ? 1 : -1;
+        return ((x < y) ? -1 : ((x > y) ? 1 : 0))*multiplier;
+    });
 }


### PR DESCRIPTION
Hello,
I think it is better to show the items sorted by the last seen time. Old Items I can'T order the most of the time.
Of cause we can also include a button in the Settings to activate this function.
I now implement this at a central place. So it always sorts the items, not only the search results.

Add a function to sort the Items by key.
Use this function to sort the items before the product site is created.
#8 