### PR TITLE
fix: behavior of all seen button

### DIFF
--- a/VineExplorer.user.js
+++ b/VineExplorer.user.js
@@ -434,7 +434,6 @@ function addLeftSideButtons(forceClean) {
 
         if (SETTINGS.DebugLevel > 10) console.log('Clicked All Seen Button');
         markAllCurrentSiteProductsAsSeen();
-        window.scrollTo(0, 0);
     });
     _div.appendChild(_setAllSeenBtn);
 


### PR DESCRIPTION
`All seen button` should only mark items as viewed, without going back to top. For this operation there is another dedicated button.