### PR TITLE
Notification when a new Favorite Item is discovered

### DIFF
--- a/VineExplorer.user.js
+++ b/VineExplorer.user.js
@@ -24,9 +24,9 @@
 // @grant        GM.setValue
 // @grant        GM.xmlHttpRequest
 // @grant        unsafeWindow
-// @require      https://raw.githubusercontent.com/Galile0/AmazonVineExplorer/FavoriteNotify/globals.js
-// @require      https://raw.githubusercontent.com/Galile0/AmazonVineExplorer/FavoriteNotify/class_db_handler.js
-// @require      https://raw.githubusercontent.com/Galile0/AmazonVineExplorer/FavoriteNotify/class_product.js
+// @require      globals.js
+// @require      class_db_handler.js
+// @require      class_product.js
 // @require      https://raw.githubusercontent.com/eligrey/FileSaver.js/v2.0.4/src/FileSaver.js
 // @require      https://raw.githubusercontent.com/Christof121/VineFetchFix/main/fetchfix.js
 // ==/UserScript==

--- a/VineExplorer.user.js
+++ b/VineExplorer.user.js
@@ -2626,7 +2626,6 @@ function stickElementToTopScrollEVhandler(elemID, dist) {
 let lastDesktopNotifikationTimestamp = 0;
 
 function updateFavoritesBtn(){
-    console.log(database.getFavEntries());
     database.getFavEntries().then((favArr) => {
         const _btnFavBadge = document.getElementById('ave-fav-items-btn-badge');
         if (favArr.length > 0) {
@@ -2700,7 +2699,13 @@ function updateNewProductsBtn() {
                         if (SETTINGS.EnableDesktopNotifikation && SETTINGS.EnableDesktopNotifikationFavorite && (shouldBypassKeywordDelay || keywordDelayPassed || SETTINGS.DesktopNotifikationDelay === 0)) {
                           desktopNotifikation(`AVE - ${new Date().toLocaleTimeString()}`, `Keyword: ${_currKey}\n${_prod.description_full}`, fixProductImageUrl(_prod.data_img_url), true, function(event) {
                             event.preventDefault();
-                            window.open(window.location.origin + _prod.link, '_blank');
+                            const newUrl = `${window.location.origin}/vine/vine-items?vine-data=${encodeURIComponent(JSON.stringify({
+                                asin: _prod.data_asin,
+                                isParentAsin: _prod.data_asin_is_parent,
+                                recommendationId: _prod.data_recommendation_id,
+                                tax: _prod.data_estimated_tax,
+                            }))}`;
+                            window.open(newUrl, '_blank');
                           });
                           lastDesktopNotifikationTimestamp = unixTimeStamp();
                         }

--- a/VineExplorer.user.js
+++ b/VineExplorer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Amazon Vine Explorer
 // @namespace    https://github.com/deburau/AmazonVineExplorer
-// @version      0.11.25
+// @version      0.11.25.1
 // @updateURL    https://raw.githubusercontent.com/deburau/AmazonVineExplorer/main/VineExplorer.user.js
 // @downloadURL  https://raw.githubusercontent.com/deburau/AmazonVineExplorer/main/VineExplorer.user.js
 // @supportURL   https://github.com/deburau/AmazonVineExplorer/issues
@@ -162,7 +162,7 @@ let showDbUpdateLogoIcon = null;
 ave_eventhandler.on('ave-database-changed', () => {
     if (SETTINGS.DebugLevel > 1) console.info('EVENT - Database has new Data for us! we should look what has changed');
     updateNewProductsBtn();
-
+    updateFavoritesBtn()
     if (showDbUpdateLogoTimeout) clearTimeout(showDbUpdateLogoTimeout);
     if (!showDbUpdateLogoIcon) showDbUpdateLogoIcon = addDBLoadingSymbol();
 
@@ -2324,7 +2324,7 @@ function initBackgroundScan() {
                     }
                     case 1: { // queue=encore | queue=encore&pn=&cn=&page=2...x
                         _subStage = parseInt(localStorage.getItem('AVE_BACKGROUND_SCAN_PAGE_CURRENT')) || 0;
-                        
+
                         if (SETTINGS.DebugLevel > 10) console.log('initBackgroundScan().loop.case.1 update PAGE_MAX');
 
                         let _pagedate = getPageinationData(document.querySelector('#ave-iframe-backgroundloader').contentWindow.document);
@@ -2433,7 +2433,7 @@ function initBackgroundScan() {
                             _stopFastScan = true;
                         }
                         if (SETTINGS.DebugLevel > 10) console.log(`checking fast scan AVE_FAST_SCAN_PREVIOUS_NEW_COUNTS=${localStorage.getItem('AVE_FAST_SCAN_PREVIOUS_NEW_COUNTS')} _backGroundScanStage=${_backGroundScanStage} newCount=${newCount}`);
-                        if (_backGroundScanStage > 0 && newCount === 0 && 
+                        if (_backGroundScanStage > 0 && newCount === 0 &&
                             (!localStorage.getItem('AVE_FAST_SCAN_PREVIOUS_NEW_COUNTS').match(/^[-0-9]+(:[-0-9]+){3}/) || localStorage.getItem('AVE_FAST_SCAN_PREVIOUS_NEW_COUNTS') == '0:0:0:0')) {
                             _stopFastScan = true;
                         }
@@ -2624,6 +2624,20 @@ function stickElementToTopScrollEVhandler(elemID, dist) {
 }
 
 let lastDesktopNotifikationTimestamp = 0;
+
+function updateFavoritesBtn(){
+    console.log(database.getFavEntries());
+    database.getFavEntries().then((favArr) => {
+        const _btnFavBadge = document.getElementById('ave-fav-items-btn-badge');
+        if (favArr.length > 0) {
+            _btnFavBadge.style.display = 'inline-block';
+            _btnFavBadge.innerText = favArr.length;
+        } else {
+            _btnFavBadge.style.display = 'none';
+            _btnFavBadge.innerText = '';
+        }
+    });
+}
 
 function updateNewProductsBtn() {
     if (AUTO_SCAN_IS_RUNNING) return;
@@ -2915,11 +2929,11 @@ function init(hasTiles) {
     const _searchbarContainer = document.getElementById('vvp-items-button-container');
 
     if (SETTINGS.EnableBtnAll) _searchbarContainer.appendChild(createNavButton('ave-btn-favorites', 'Alle Produkte', '', SETTINGS.BtnColorAllProducts, () => { createNewSite(PAGETYPE.ALL); }));
-    _searchbarContainer.appendChild(createNavButton('ave-btn-favorites', 'Favoriten', '', SETTINGS.BtnColorFavorites, () => {createNewSite(PAGETYPE.FAVORITES);}));
+    _searchbarContainer.appendChild(createNavButton('ave-btn-favorites', 'Favoriten', '', SETTINGS.BtnColorFavorites, () => {createNewSite(PAGETYPE.FAVORITES);}, 'ave-fav-items-btn-badge', '-'));
     _searchbarContainer.appendChild(createNavButton('ave-btn-list-new', 'Neue Einträge', 'ave-new-items-btn', SETTINGS.BtnColorNewProducts, () => {createNewSite(PAGETYPE.NEW_ITEMS);}, 'ave-new-items-btn-badge', '-'));
 
     updateNewProductsBtn();
-
+    updateFavoritesBtn();
     // Searchbar
     const _searchBarSpan = document.createElement('span');
     _searchBarSpan.setAttribute('class', 'ave-search-container');

--- a/globals.js
+++ b/globals.js
@@ -224,6 +224,8 @@ SETTINGS_USERCONFIG_DEFINES.push({key: 'EnablePaginationTop', type: 'bool', name
 SETTINGS_USERCONFIG_DEFINES.push({key: 'EnableBackgroundScan', type: 'bool', name: 'Enable Background Scan', description: 'Enables the Background scan, if disabled you will find a Button for Autoscan on the Vine Website'});
 SETTINGS_USERCONFIG_DEFINES.push({key: 'EnableInfiniteScrollLiveQuerry', type: 'bool', name: 'Enable Infiniti Scroll Live Querry', description: 'If enabled the Products of the All Products Page will get querryd from Amazon directls otherwise they will get loaded from Database(faster)'});
 SETTINGS_USERCONFIG_DEFINES.push({key: 'EnableDesktopNotifikation', type: 'bool', name: 'Enable Desktop Notifications', description: 'Enable Desktop Notifications if new Products are detected'});
+SETTINGS_USERCONFIG_DEFINES.push({key: 'EnableDesktopNotifikationFavorite', type: 'bool', name: 'Enable Desktop Notifications only for Favorites', description: 'When enabled, desktop notifications will only be sent for favorite items (requires Enable Desktop Notifications to be enabled)'});
+SETTINGS_USERCONFIG_DEFINES.push({key: 'EnableDesktopNotifikationFavoriteIgnoreDelay', type: 'bool', name: 'Ignore notification delay for Favorites', description: 'When enabled, favorite items will trigger notifications immediately, bypassing the Desktop Notification Delay setting'});
 SETTINGS_USERCONFIG_DEFINES.push({key: 'EnableAutoMarkFavorite', type: 'bool', name: 'Enable auto marking product as favotite', description: 'If a new product matches a highlight keyword it is automatically marked as favorite'});
 SETTINGS_USERCONFIG_DEFINES.push({key: 'EnableBtnMarkAllAsSeen', type: 'bool', name: 'Enable Button Mark all as seen', description: 'Enable the Button Mark all as seen'});
 SETTINGS_USERCONFIG_DEFINES.push({key: 'ShowFirstSeen', type: 'bool', name: 'Show first seen instead of last seen', description: 'Instead of the &quot;Last seen&quot; date in the product box show the date, the item was first seen'});
@@ -277,6 +279,8 @@ class SETTINGS_DEFAULT {
     EnableBackgroundScan = true;
     EnableInfiniteScrollLiveQuerry = false;
     EnableDesktopNotifikation = false;
+    EnableDesktopNotifikationFavorite = false;
+    EnableDesktopNotifikationFavoriteIgnoreDelay = false;
     EnableAutoMarkFavorite = false;
     EnableBtnAll = true;
     EnablePaginationTop = true;


### PR DESCRIPTION
There are now two new Options in the Settings:
* Enable Desktop Notifications only for Favorites
* Ignore notification delay for Favorites

Both Options only take effect when Notifications in general are enabled (Enable Desktop Notifications)
If Desktop Notifications are enabled the first new Options restricts the notification to only trigger when a new item matching a keyword is added to the favorites (i.e. Enable auto marking product as favotite is turned on).
This way a user can specify a keyword and whenever an item is found it is added to the favorite tab, a notification is sent to the user (the notification also stays on top), and clicking the notification goes directly to the vine page with details about the item.

Furthermore it can be configure if favorite notifications should bypass the notification delay timer.